### PR TITLE
fixed list note integration test

### DIFF
--- a/test/integration/findings_api_v1/input/json/note_for_list_note.json
+++ b/test/integration/findings_api_v1/input/json/note_for_list_note.json
@@ -1,0 +1,21 @@
+{
+    "provider_id":"sdktest",
+	"short_description":"sdk test findings",
+	"long_description":"sdk test findings",
+	"kind":"FINDING",
+	"id":"sdk_note_id1",
+	"reported_by":{
+        "id":"1",
+        "title":"test1",
+        "url":"www.test.com"
+    },
+	"finding":{
+        "severity": "LOW",
+        "next_steps": [
+            {
+                "title": "string",
+                "url": "string"
+            }
+        ]
+    }
+}

--- a/test/integration/findings_api_v1/test_note.py
+++ b/test/integration/findings_api_v1/test_note.py
@@ -84,11 +84,31 @@ class TestNote(unittest.TestCase):
 
     def test_list_note(self):
         print("test_list_note")
+        with open(jsonDir + "note_for_list_note.json") as f:
+            data = json.load(f)
+        data['id'] = generate_unique_string('note')
+        data['provider_id'] = generate_unique_string('list_note_provider')
+        
+        resp = TestNote.ibm_security_advisor_findings_api_sdk.create_note(
+            account_id=TestNote.account_id,
+            **data
+        )
+        print(data)
+
         resp = TestNote.ibm_security_advisor_findings_api_sdk.list_notes(
             account_id=TestNote.account_id,
-            **TestNote.note_data,
+            provider_id=data['provider_id']
         )
-        assert resp.result['notes'][0]['id'] == TestNote.note_data['id']
+        assert resp.result['notes'][0]['id'] == data['id']
+
+        delResp = TestNote.ibm_security_advisor_findings_api_sdk.delete_note(
+            account_id=TestNote.account_id,
+            **data,
+            note_id=data['id']
+        )
+
+        if delResp.result != {}:
+            print("note deletion is failed", delResp)
 
     def test_delete_note(self):
         print("test_delete_note")


### PR DESCRIPTION
Added specific data for list note function which creates a note with a unique provider and note id which makes sure that this provider always has one note and the thus the first note ID is always what is expected (if things are in normal flow).